### PR TITLE
Improve naming for product detail request class

### DIFF
--- a/src/Request/Product/ListProductRequest.php
+++ b/src/Request/Product/ListProductRequest.php
@@ -2,43 +2,14 @@
 
 namespace Nascom\TeamleaderApiClient\Request\Product;
 
-use Nascom\TeamleaderApiClient\Request\AbstractPostRequest;
-
 /**
  * Class ListProductRequest
  *
  * @package Nascom\TeamleaderApiClient\Request\Product
+ * @deprecated Replaced by the RetrieveProductRequest class
+ * @see RetrieveProductRequest
  */
-class ListProductRequest extends AbstractPostRequest
+class ListProductRequest extends RetrieveProductRequest
 {
-    /**
-     * ListProductRequest constructor.
-     *
-     * @param $product_id
-     * @param array $options
-     *   Optional parameters:
-     *   - include_all_custom_fields
-     *   - include_photos
-     */
-    public function __construct($product_id, array $options = [])
-    {
-        $this->options = $options;
-        $this->setProductId($product_id);
-    }
 
-    /**
-     * @param $product_id
-     */
-    public function setProductId($product_id)
-    {
-        $this->options['product_id'] = $product_id;
-    }
-
-    /**
-     * @return string
-     */
-    public function getUri()
-    {
-        return 'getProduct.php';
-    }
 }

--- a/src/Request/Product/RetrieveProductRequest.php
+++ b/src/Request/Product/RetrieveProductRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Nascom\TeamleaderApiClient\Request\Product;
+
+use Nascom\TeamleaderApiClient\Request\AbstractPostRequest;
+
+/**
+ * Class RetrieveProductRequest
+ *
+ * @package Nascom\TeamleaderApiClient\Request\Product
+ */
+class RetrieveProductRequest extends AbstractPostRequest
+{
+    /**
+     * RetrieveProductRequest constructor.
+     *
+     * @param $product_id
+     * @param array $options
+     *   Optional parameters:
+     *   - include_all_custom_fields
+     *   - include_photos
+     */
+    public function __construct($product_id, array $options = [])
+    {
+        $this->options = $options;
+        $this->setProductId($product_id);
+    }
+
+    /**
+     * @param $product_id
+     */
+    public function setProductId($product_id)
+    {
+        $this->options['product_id'] = $product_id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUri()
+    {
+        return 'getProduct.php';
+    }
+}


### PR DESCRIPTION
Fetching the detail of a product used the `ListProductRequest` class. Since the other modules use the 'RetrieveXXXRequest' instead of the `ListXXXRequest` for the detail, this was kinda confusing.

This PR creates a new class `RetrieveProductRequest` that is a 1-on-1 copy of the `ListProductRequest` and deprecates the `ListProductRequest` class in favour of `RetrieveProductRequest`.

