### PR TITLE
Fix bad request when retrieving creditnote detail

### DIFF
--- a/src/Request/Creditnote/RetrieveCreditnoteRequest.php
+++ b/src/Request/Creditnote/RetrieveCreditnoteRequest.php
@@ -28,7 +28,7 @@ class RetrieveCreditnoteRequest extends AbstractPostRequest
      */
     public function setCreditnoteId($credit_id)
     {
-        $this->options['credit_id'] = $credit_id;
+        $this->options['creditnote_id'] = $credit_id;
     }
 
     /**


### PR DESCRIPTION
When retrieving a creditnote detail, the Teamleader API threw an error 400 (bad request) because the required option "creditnote_id" was missing.

The RetrieveCreditnoteRequest class was using the "credit_id" option intead of "creditnote_id".