### PR TITLE
Add use statements for class TaxRatesListRequest

### DIFF
--- a/src/Request/Invoicing/TaxRates/TaxRatesListRequest.php
+++ b/src/Request/Invoicing/TaxRates/TaxRatesListRequest.php
@@ -2,8 +2,11 @@
 
 namespace Nascom\TeamleaderApiClient\Request\Invoicing\TaxRates;
 
+use Nascom\TeamleaderApiClient\Request\Attributes\Filter\FilterInterface;
 use Nascom\TeamleaderApiClient\Request\Attributes\Filter\FilterTrait;
+use Nascom\TeamleaderApiClient\Request\Attributes\Page\PageInterface;
 use Nascom\TeamleaderApiClient\Request\Attributes\Page\PageTrait;
+use Nascom\TeamleaderApiClient\Request\Attributes\Sort\SortInterface;
 use Nascom\TeamleaderApiClient\Request\Attributes\Sort\SortTrait;
 use Nascom\TeamleaderApiClient\Request\GetRequest;
 use Nascom\TeamleaderApiClient\Request\MultipleMethodsTrait;


### PR DESCRIPTION
When trying to get a list of tax rates, I'm getting errors that the defined interfaces in this class are not found.
Here is a pull request to add the correct use statements.