### PR TITLE
Create deals in V2

### DIFF
--- a/src/Model/Deal/DealBase.php
+++ b/src/Model/Deal/DealBase.php
@@ -25,6 +25,11 @@ abstract class DealBase extends ModelBase
     /**
      * @var string
      */
+    private $summary;
+
+    /**
+     * @var string
+     */
     private $reference;
 
     /**
@@ -111,6 +116,22 @@ abstract class DealBase extends ModelBase
     public function setTitle($title)
     {
         $this->title = $title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSummary()
+    {
+        return $this->summary;
+    }
+
+    /**
+     * @param string $reference
+     */
+    public function setSummary($summary)
+    {
+        $this->summary = $summary;
     }
 
     /**

--- a/src/Request/Deals/Deals/DealsCreateRequest.php
+++ b/src/Request/Deals/Deals/DealsCreateRequest.php
@@ -41,7 +41,7 @@ class DealsCreateRequest extends PostRequest
         }
 
         $this->body = array_filter($deal, function ($value) {
-            return !empty($value);
+            return isset($value);
         });
     }
 

--- a/src/Request/Deals/Deals/DealsCreateRequest.php
+++ b/src/Request/Deals/Deals/DealsCreateRequest.php
@@ -26,15 +26,17 @@ class DealsCreateRequest extends PostRequest
 
         unset($deal['lead']['contact_person']);
 
-        $customFields = $deal['custom_fields'];
-        $deal['custom_fields'] = [];
+        if (isset($deal['custom_fields'])) {
+            $customFields = $deal['custom_fields'];
+            $deal['custom_fields'] = [];
 
-        foreach ($customFields as $field) {
-            if (isset($field['value'])) {
-                $deal['custom_fields'][] = [
-                    'id' => $field['definition']['id'],
-                    'value' => $field['value'],
-                ];
+            foreach ($customFields as $field) {
+                if (isset($field['value'])) {
+                    $deal['custom_fields'][] = [
+                        'id' => $field['definition']['id'],
+                        'value' => $field['value'],
+                    ];
+                }
             }
         }
 

--- a/src/Serializer/FieldDescription/Model/Deal/DealFieldDescriptionBase.php
+++ b/src/Serializer/FieldDescription/Model/Deal/DealFieldDescriptionBase.php
@@ -24,6 +24,7 @@ abstract class DealFieldDescriptionBase extends FieldDescriptionBase
         return [
             'id',
             'title',
+            'summary',
             'reference',
             'status',
             'lead' => ['target_class' => Lead::class],


### PR DESCRIPTION
Various fixes to create deals:
- Add summary, this was added to the Teamleader API in February 2020.
- Fix PHP warning regarding unexisting array key 'custom_fields' when no custom fields have added to the deal.
- Allow '0' (zero) as value.