### PR TITLE
Cuzzle dependency is not used but breaks Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
     "php-http/discovery": "^1.0",
     "php-http/client-common": "^1.0|^2.0",
     "nascom/oauth2-teamleader": "^0.1",
-    "namshi/cuzzle": "^2.0"
   },
   "require-dev": {
     "phpspec/phpspec": "^3.2",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "php-http/message-factory": "^1.0",
     "php-http/discovery": "^1.0",
     "php-http/client-common": "^1.0|^2.0",
-    "nascom/oauth2-teamleader": "^0.1",
+    "nascom/oauth2-teamleader": "^0.1"
   },
   "require-dev": {
     "phpspec/phpspec": "^3.2",


### PR DESCRIPTION
namshi/cuzzle is a current dependency but isn't used in the code. Cuzzle explicitly depends on Guzzle6, which makes this breaking in projects using Guzzle 7. Since this is a non-required dependency, I think this can be removed to resolve the breakage.