### PR TITLE
Pass content-type header to fix filters

### DIFF
--- a/src/Http/ApiClient/ApiClient.php
+++ b/src/Http/ApiClient/ApiClient.php
@@ -69,7 +69,11 @@ class ApiClient implements ApiClientInterface
      */
     public function handle(RequestInterface $request)
     {
-        $options = [];
+        $options = [
+            'headers' => [
+                'Content-Type' => 'application/json',
+            ],
+        ];
         $body = $request->getBody();
 
         if ($request instanceof FilterInterface) {


### PR DESCRIPTION
I was implementing this library using the a Guzzle7 http client. When trying to do a request to `companies.list` with a filter, the filter did not seem to be applied.

By changing my own Guzzle Client to always pass the `Content-Type` header, this was fixed. This shouldn't be necessary to configure on the outside though since the library itself knows that it always sends JSON bodies. Let's thus adapt the API Client itself so that custom http clients don't have to add this header themselves.